### PR TITLE
Looser function name comparisons when deserialized

### DIFF
--- a/lib/complexValues/function.js
+++ b/lib/complexValues/function.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const functionNameSupport = require('function-name-support')
+
 const constants = require('../constants')
 const getStringTag = require('../getStringTag')
 const isEnumerable = require('../isEnumerable')
@@ -52,10 +54,6 @@ class FunctionValue extends object.ObjectValue {
       }
     })
   }
-
-  serialize () {
-    return [this.name, generatorsHaveGeneratorTag, super.serialize()]
-  }
 }
 Object.defineProperty(FunctionValue.prototype, 'tag', { value: tag })
 
@@ -100,18 +98,47 @@ class DescribedFunctionValue extends object.DescribedMixin(FunctionValue) {
 
     return { size, next }
   }
+
+  serialize () {
+    return [functionNameSupport.bitFlags, this.name, generatorsHaveGeneratorTag, super.serialize()]
+  }
 }
 
 class DeserializedFunctionValue extends object.DeserializedMixin(FunctionValue) {
   constructor (state, recursor) {
-    super(state[2], recursor)
-    this.name = state[0]
-    this.trustStringTag = state[1]
+    super(state[3], recursor)
+    this.functionNameSupportFlags = state[0]
+    this.name = state[1]
+    this.trustStringTag = state[2]
   }
 
   compare (expected) {
     if (this.tag !== expected.tag) return UNEQUAL
-    if (this.name !== expected.name) return UNEQUAL
+
+    if (this.name !== expected.name) {
+      if (this.functionNameSupportFlags === functionNameSupport.bitFlags) {
+        // The engine used to create the serialization supports the same
+        // function name inference as the current engine. That said, unless
+        // the engine has full support for name inference, it's possible that
+        // names were lost simply due to refactoring. Names are unequal if
+        // the engine has full support, or if names were inferred.
+        if (functionNameSupport.hasFullSupport === true || (this.name !== '' && expected.name !== '')) return UNEQUAL
+      } else if (functionNameSupport.isSubsetOf(this.functionNameSupportFlags)) {
+        // The engine used to create the serialization could infer more function
+        // names than the current engine. Assume `expected.name` comes from the
+        // current engine and treat the names as unequal only if the current
+        // engine could infer a name.
+        if (expected.name !== '') return UNEQUAL
+      } else {
+        /* istanbul ignore else */
+        if (functionNameSupport.isSupersetOf(this.functionNameSupportFlags)) {
+          // The engine used to create the serialization could infer fewer
+          // function names than the current engine. Treat the names as unequal
+          // only if a name was in the serialization.
+          if (this.name !== '') return UNEQUAL
+        }
+      }
+    }
 
     // Assume `stringTag` is either 'Function' or 'GeneratorFunction', and that
     // it always equals `ctor`. Since Node.js 4 only provides 'Function', even
@@ -121,5 +148,9 @@ class DeserializedFunctionValue extends object.DeserializedMixin(FunctionValue) 
     if (this.trustStringTag && generatorsHaveGeneratorTag && this.stringTag !== expected.stringTag) return UNEQUAL
 
     return SHALLOW_EQUAL
+  }
+
+  serialize () {
+    return [this.functionNameSupportFlags, this.name, this.trustStringTag, super.serialize()]
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "esutils": "^2.0.2",
     "fast-diff": "^1.1.1",
+    "function-name-support": "^0.2.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.flattendeep": "^4.4.0",
     "lodash.merge": "^4.6.0",
@@ -44,8 +45,10 @@
     "codecov": "^2.1.0",
     "left-pad": "^1.1.3",
     "lodash.isequal": "^4.5.0",
+    "mock-require": "^2.0.2",
     "nyc": "^10.1.2",
-    "pretty-format": "^19.0.0"
+    "pretty-format": "^19.0.0",
+    "proxyquire": "^1.8.0"
   },
   "as-i-preach": {
     "allowDevDependencies": [

--- a/test/function-names.js
+++ b/test/function-names.js
@@ -1,0 +1,79 @@
+import {serial as test} from 'ava'
+import mock from 'mock-require'
+import proxyquire from 'proxyquire'
+
+const stub = {
+  isSubsetOf (otherFlags) {
+    return (this.bitFlags & otherFlags) === this.bitFlags
+  },
+  isSupersetOf (otherFlags) {
+    return (this.bitFlags & otherFlags) === otherFlags
+  }
+}
+test.beforeEach(() => {
+  Object.assign(stub, {
+    support: {},
+    hasFullSupport: false,
+    bitFlags: 0b101
+  })
+})
+
+mock('../lib/complexValues/function', proxyquire('../lib/complexValues/function', {
+  'function-name-support': stub
+}))
+
+const {compareDescriptors, describe, deserialize, serialize} = require('..')
+
+const prepareLhs = fn => deserialize(serialize(describe(fn)))
+
+function foo () {}
+function bar () {}
+
+test('same flags, full support, different names', t => {
+  stub.hasFullSupport = true
+  t.false(compareDescriptors(prepareLhs(foo), describe(bar)))
+})
+
+test('same flags, not full support, lhs has no name', t => {
+  t.true(compareDescriptors(prepareLhs(() => {}), describe(bar)))
+})
+
+test('same flags, not full support, rhs has no name', t => {
+  t.true(compareDescriptors(prepareLhs(foo), describe(() => {})))
+})
+
+test('subset, different names', t => {
+  const lhs = prepareLhs(foo)
+  stub.bitFlags = 0b001
+  t.false(compareDescriptors(lhs, describe(bar)))
+})
+
+test('subset, lhs has no name', t => {
+  const lhs = prepareLhs(() => {})
+  stub.bitFlags = 0b001
+  t.false(compareDescriptors(lhs, describe(bar)))
+})
+
+test('subset, rhs has no name', t => {
+  const lhs = prepareLhs(foo)
+  stub.bitFlags = 0b001
+  t.true(compareDescriptors(lhs, describe(() => {})))
+})
+
+test('superset, different names', t => {
+  const lhs = prepareLhs(foo)
+  stub.bitFlags = 0b111
+  t.false(compareDescriptors(lhs, describe(bar)))
+})
+
+test('superset, lhs has no name', t => {
+  const lhs = prepareLhs(() => {})
+  stub.bitFlags = 0b111
+  t.true(compareDescriptors(lhs, describe(bar)))
+})
+
+test('superset, rhs has no name', t => {
+  const lhs = prepareLhs(foo)
+  stub.bitFlags = 0b111
+  t.false(compareDescriptors(lhs, describe(() => {})))
+})


### PR DESCRIPTION
Depending on available function name inference support, loosen name comparisons when the left-hand side is a deserialized function descriptor. Fixes #20.