### PR TITLE
Invert gutters

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -57,6 +57,7 @@ function compareComplexShape (lhs, rhs) {
 
 function diffDescriptors (lhs, rhs, options) {
   const theme = themeUtils.normalize(options)
+  const invert = options ? options.invert === true : false
 
   const circular = new Circular()
   const lhsLookup = new Map()
@@ -406,7 +407,7 @@ function diffDescriptors (lhs, rhs, options) {
     }
   } while (topIndex >= 0)
 
-  return buffer.toString({diff: true, theme})
+  return buffer.toString({diff: true, invert, theme})
 }
 exports.diffDescriptors = diffDescriptors
 

--- a/lib/lineBuilder.js
+++ b/lib/lineBuilder.js
@@ -3,9 +3,14 @@
 const ACTUAL = Symbol('lineBuilder.gutters.ACTUAL')
 const EXPECTED = Symbol('lineBuilder.gutters.EXPECTED')
 
-function translateGutter (theme, gutter) {
-  if (gutter === ACTUAL) return theme.diffGutters.actual
-  if (gutter === EXPECTED) return theme.diffGutters.expected
+function translateGutter (theme, invert, gutter) {
+  if (invert) {
+    if (gutter === ACTUAL) return theme.diffGutters.expected
+    if (gutter === EXPECTED) return theme.diffGutters.actual
+  } else {
+    if (gutter === ACTUAL) return theme.diffGutters.actual
+    if (gutter === EXPECTED) return theme.diffGutters.expected
+  }
   return theme.diffGutters.padding
 }
 
@@ -46,7 +51,7 @@ class Line {
   toString (options) {
     if (options.diff === false) return this.stringValue
 
-    return translateGutter(options.theme, this.gutter) + this.stringValue
+    return translateGutter(options.theme, options.invert, this.gutter) + this.stringValue
   }
 
   mergeWithInfix (infix, other) {
@@ -122,8 +127,39 @@ class Collection {
       .append(other)
   }
 
-  toString (theme) {
-    return Array.from(this, line => line.toString(theme)).join('\n')
+  toString (options) {
+    let lines = this
+
+    if (options.invert) {
+      lines = new Collection()
+      let buffer = new Collection()
+
+      let prev = null
+      for (const line of this) {
+        if (line.gutter === ACTUAL) {
+          if (prev !== null && prev.gutter !== ACTUAL && !buffer.isEmpty) {
+            lines.append(buffer)
+            buffer = new Collection()
+          }
+
+          buffer.append(line)
+        } else if (line.gutter === EXPECTED) {
+          lines.append(line)
+        } else {
+          if (!buffer.isEmpty) {
+            lines.append(buffer)
+            buffer = new Collection()
+          }
+
+          lines.append(line)
+        }
+
+        prev = line
+      }
+      lines.append(buffer)
+    }
+
+    return Array.from(lines, line => line.toString(options)).join('\n')
   }
 
   mergeWithInfix (infix, from) {

--- a/lib/lineBuilder.js
+++ b/lib/lineBuilder.js
@@ -8,7 +8,6 @@ function translateGutter (theme, gutter) {
   if (gutter === EXPECTED) return theme.diffGutters.expected
   return theme.diffGutters.padding
 }
-exports.translateGutter = translateGutter
 
 class Line {
   constructor (isFirst, isLast, gutter, stringValue) {

--- a/test/__snapshots__/diff.js.snap
+++ b/test/__snapshots__/diff.js.snap
@@ -922,3 +922,15 @@ exports[`does not diff multiline string values in maps when key is complex 1`] =
 %diffGutters.expected#+ %  %string.open%bar%string.close%%string.multiline.end#\`%%mapEntry.after#,%
 %diffGutters.padding#  %%object.closeBracket#}%"
 `;
+
+exports[`inverted diffs 1`] = `
+"%diffGutters.padding#  %%object.openBracket#{%
+%diffGutters.padding#  %  baz%property.separator#: %%string.multiline.start#\`%%string.diff.equal.open%qux%string.diff.equal.close%%string.controlPicture.open%␊%string.controlPicture.close%%string.diff.equal.open%%string.diff.equal.close%
+%diffGutters.actual#- %  %string.diff.insertLine.open%corge%string.controlPicture.open%␊%string.controlPicture.close%%string.diff.insertLine.close%
+%diffGutters.actual#- %  %string.diff.insertLine.open%quux%string.diff.insertLine.close%%string.multiline.end#\`%%property.after#,%
+%diffGutters.expected#+ %  %string.diff.deleteLine.open%quux%string.controlPicture.open%␊%string.controlPicture.close%%string.diff.deleteLine.close%
+%diffGutters.expected#+ %  %string.diff.deleteLine.open%corge%string.diff.deleteLine.close%%string.multiline.end#\`%%property.after#,%
+%diffGutters.actual#- %  foo%property.separator#: %%string.line.open#'%%string.diff.insertLine.open%BAR%string.diff.insertLine.close%%string.line.close#'%%property.after#,%
+%diffGutters.expected#+ %  foo%property.separator#: %%string.line.open#'%%string.diff.deleteLine.open%bar%string.diff.deleteLine.close%%string.line.close#'%%property.after#,%
+%diffGutters.padding#  %%object.closeBracket#}%"
+`;

--- a/test/diff.js
+++ b/test/diff.js
@@ -4,7 +4,7 @@ import {diff as _diff} from '../lib/diff'
 
 import theme, {normalizedTheme, checkThemeUsage} from './_instrumentedTheme'
 
-const diff = (actual, expected) => _diff(actual, expected, {theme})
+const diff = (actual, expected, {invert} = {}) => _diff(actual, expected, {invert, theme})
 test.after(checkThemeUsage)
 
 void (
@@ -429,4 +429,14 @@ test('diffs regexps', t => {
 
 test('diffs buffers', t => {
   t.snapshot(diff(Buffer.from('decafbad', 'hex'), Buffer.from('flat white', 'utf8')))
+})
+
+test('inverted diffs', t => {
+  t.snapshot(diff({
+    foo: 'bar',
+    baz: 'qux\nquux\ncorge'
+  }, {
+    foo: 'BAR',
+    baz: 'qux\ncorge\nquux'
+  }, {invert: true}))
 })


### PR DESCRIPTION
When Concordance is used for snapshot testing the `actual` (left-hand
side) value should be the deserialized snapshot. This can make the diff
result confusing since the user might reasonably presume the snapshot
value is the *expected* value, with a `+` gutter, not a `-` gutter.

This commit adds an option to invert diffs, reordering diff lines and
changing the gutters so it looks like the snapshot value was indeed
the *expected* value.