### PR TITLE
Fix serialization of non-collection objects with a 'length' property

### DIFF
--- a/lib/hasLength.js
+++ b/lib/hasLength.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const isLength = require('lodash.islength')
+
 const hop = Object.prototype.hasOwnProperty
+
 function hasLength (obj) {
   return (
     Array.isArray(obj) ||
     (hop.call(obj, 'length') &&
-      typeof obj.length === 'number' &&
+      isLength(obj.length) &&
       (obj.length === 0 || '0' in obj))
   )
 }

--- a/lib/hasLength.js
+++ b/lib/hasLength.js
@@ -2,6 +2,11 @@
 
 const hop = Object.prototype.hasOwnProperty
 function hasLength (obj) {
-  return Array.isArray(obj) || (hop.call(obj, 'length') && typeof obj.length === 'number')
+  return (
+    Array.isArray(obj) ||
+    (hop.call(obj, 'length') &&
+      typeof obj.length === 'number' &&
+      (obj.length === 0 || '0' in obj))
+  )
 }
 module.exports = hasLength

--- a/package-lock.json
+++ b/package-lock.json
@@ -5443,6 +5443,11 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
+    "lodash.islength": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
+      "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "js-string-escape": "^1.0.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.flattendeep": "^4.4.0",
+    "lodash.islength": "^4.0.1",
     "lodash.merge": "^4.6.1",
     "md5-hex": "^2.0.0",
     "semver": "^5.5.1",

--- a/test/serialize-and-encode.js
+++ b/test/serialize-and-encode.js
@@ -75,6 +75,7 @@ test('object with complex property', useDeserialized, {foo: {}})
 test('object with well known symbol key', useDeserialized, {[Symbol.unscopables]: 'bar'})
 test('object with registered symbol key', useDeserialized, {[Symbol.for('foo')]: 'bar'})
 test('object with arbitrary symbol key', useDeserialized, {[Symbol('foo')]: 'bar'})
+test('object with length property', useDeserialized, { length: 12345678 })
 
 test('symbol properties are reordered despite serialization', t => {
   const s1 = Symbol('s1')

--- a/test/serialize-and-encode.js
+++ b/test/serialize-and-encode.js
@@ -76,6 +76,10 @@ test('object with well known symbol key', useDeserialized, {[Symbol.unscopables]
 test('object with registered symbol key', useDeserialized, {[Symbol.for('foo')]: 'bar'})
 test('object with arbitrary symbol key', useDeserialized, {[Symbol('foo')]: 'bar'})
 test('object with length property', useDeserialized, { length: 12345678 })
+test('object with negative length property', useDeserialized, { length: -12345678 })
+test('object with NaN length property', useDeserialized, { length: NaN })
+test('object with infinite length property', useDeserialized, { length: Infinity })
+test('object with fractional length property', useDeserialized, { length: 1.5 })
 
 test('symbol properties are reordered despite serialization', t => {
   const s1 = Symbol('s1')


### PR DESCRIPTION
This changes serialization of objects that happen to have a `length` property but are not intended to be Array-like. When objects have a very large `length` and are treated as arrays, they can take a very long time to serialize and/or cause an OOM error.

All existing tests pass, and I added a new one (and confirmed that it causes an OOM error without this change).

The only time this would be backwards-incompatible is if people were expecting:

* *Sparse* objects with a `length` to be treated as arrays. For example, `'0' in arr` fails for `new Array(10)`, although that particular case is handled by `Array.isArray`. IMO, it seems fine for such objects to just get the plain-Object treatment.
* Objects with a *negative* `length` to be treated as arrays.

Fixes #47.