### PR TITLE
Handle undescribed own properties

### DIFF
--- a/lib/getObjectKeys.js
+++ b/lib/getObjectKeys.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const isEnumerable = require('./isEnumerable')
+
 function getObjectKeys (obj, excludeListItemAccessorsBelowLength) {
   const keys = []
   let size = 0
@@ -17,13 +19,13 @@ function getObjectKeys (obj, excludeListItemAccessorsBelowLength) {
       accept = !Number.isInteger(index) || index < 0 || index >= excludeListItemAccessorsBelowLength
     }
 
-    if (accept && Object.getOwnPropertyDescriptor(obj, name).enumerable) {
+    if (accept && isEnumerable(obj, name)) {
       keys[size++] = name
     }
   }
 
   for (const symbol of symbolCandidates) {
-    if (Object.getOwnPropertyDescriptor(obj, symbol).enumerable) {
+    if (isEnumerable(obj, symbol)) {
       keys[size++] = symbol
     }
   }

--- a/test/odd-properties.js
+++ b/test/odd-properties.js
@@ -1,0 +1,9 @@
+const test = require('ava')
+const { compare } = require('..')
+
+test('ignores undescribed own properties', t => {
+  const a = new Proxy({ a: 1 }, {
+    getOwnPropertyDescriptor (target, prop) {},
+  })
+  t.true(compare(a, {}).pass)
+})


### PR DESCRIPTION
This PR treats own properties that lack descriptors as non-enumerable (skipping them). This prevents throwing when the input contains certain strange `Proxy` objects.

Closes #71.