### PR TITLE
 replace some of lodash with native functions

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const flattenDeep = require('lodash/flattenDeep')
-
 // Indexes are hexadecimal to make reading the binary output easier.
 const valueTypes = {
   zero: 0x00,
@@ -167,7 +165,7 @@ function buildBuffer (numberOrArray) {
     return byte
   }
 
-  const array = flattenDeep(numberOrArray)
+  const array = numberOrArray.flat(Infinity)
   const buffers = new Array(array.length)
   let byteLength = 0
   for (const [index, element] of array.entries()) {

--- a/lib/hasLength.js
+++ b/lib/hasLength.js
@@ -1,14 +1,11 @@
 'use strict'
 
-const isLength = require('lodash/isLength')
-
 const hop = Object.prototype.hasOwnProperty
 
 function hasLength (obj) {
   return (
     Array.isArray(obj) ||
     (hop.call(obj, 'length') &&
-      isLength(obj.length) &&
       (obj.length === 0 || '0' in obj))
   )
 }

--- a/lib/themeUtils.js
+++ b/lib/themeUtils.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const cloneDeep = require('lodash/cloneDeep')
-const merge = require('lodash/merge')
+const cloneDeep = require('lodash.clonedeep')
+const merge = require('lodash.merge')
 
 const pluginRegistry = require('./pluginRegistry')
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "esutils": "^2.0.3",
     "fast-diff": "^1.2.0",
     "js-string-escape": "^1.0.1",
-    "lodash": "^4.17.15",
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.merge": "^4.6.2",
     "md5-hex": "^3.0.1",
     "semver": "^7.3.2",
     "well-known-symbols": "^2.0.0"


### PR DESCRIPTION
- The recursive cloning methods were retained as their individual npm packages
- I tried replacing `lodash.merge` with `Object.assign` but some tests failed; seems the two methods may handle `undefined` differently
- `Array.prototype.flat` was introduced in NodeJS v11 so you'll need to drop v10 from the testing matrix
- is `hasLength` even used? The only reference to it seems unused