### PR TITLE
Support ANSI escapes in strings by replacing `\x1b` with ␛

### DIFF
--- a/lib/primitiveValues/string.js
+++ b/lib/primitiveValues/string.js
@@ -25,6 +25,13 @@ exports.tag = tag
 // http://graphemica.com/blocks/control-pictures where applicable.
 function basicEscape (string) {
   return string.replace(/\\/g, '\\\\')
+    .replace(/\x00/g, "␀")
+    .replace(/\x1b/g, "␛")
+    .replace(/\x11/g, "␑")
+    .replace(/\x12/g, "␒")
+    .replace(/\x13/g, "␓")
+    .replace(/\x14/g, "␔")
+
 }
 
 const CRLF_CONTROL_PICTURE = '\u240D\u240A'


### PR DESCRIPTION
There is a library that I saw the other day that does exactly this - replaces ASCII control characters with a sigil... but now I can't find it. @sindresorhus I think I saw it in one of your projects, do you remember what it was called?

Anyway I needed to hack this up to get unblocked, and I had this bit of replacement locally so I used that. (I'm using DC1-4 in a similar way that you're using `CONTROL_PICTURE` so they show up in my strings). I left them in specifically because they're a bit of a code smell. Why only these 5 sigils? Why not all the ASCII control characters? 

I wonder if this would be better handled as an option to concordance... but then again I don't think it's a bad thing to output these control characters as _printable_ characters, so the argument for having it be the default behaviour could be made.

Anyway I'll propose this as a starting point, but I don't think it's polished and ready - I'm happy to do more work on it.