### PR TITLE
Add item and property display limits

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -4,6 +4,7 @@ const Circular = require('./Circular')
 const Indenter = require('./Indenter')
 const constants = require('./constants')
 const describe = require('./describe')
+const itemAndPropertyLimit = require('./itemAndPropertyLimit')
 const lineBuilder = require('./lineBuilder')
 const recursorUtils = require('./recursorUtils')
 const shouldCompareDeep = require('./shouldCompareDeep')
@@ -62,6 +63,7 @@ function diffDescriptors (lhs, rhs, options) {
   const lhsCircular = new Circular()
   const rhsCircular = new Circular()
   const maxDepth = (options && options.maxDepth) || 0
+  const limits = itemAndPropertyLimit.normalize(options)
 
   let indent = new Indenter(0, '  ')
 
@@ -76,7 +78,13 @@ function diffDescriptors (lhs, rhs, options) {
   const isCircular = descriptor => lhsCircular.has(descriptor) || rhsCircular.has(descriptor)
 
   const format = (builder, subject, circular, depthOffset = 0) => {
-    if (diffIndex >= 0 && !diffStack[diffIndex].shouldFormat(subject)) return
+    if (diffIndex >= 0) {
+      const shouldFormat = builder === lineBuilder && diffStack[diffIndex].shouldFormatEqual
+        ? diffStack[diffIndex].shouldFormatEqual
+        : diffStack[diffIndex].shouldFormat
+
+      if (!shouldFormat(subject)) return
+    }
 
     if (circular.has(subject)) {
       diffStack[diffIndex].formatter.append(builder.single(theme.circular))
@@ -130,7 +138,9 @@ function diffDescriptors (lhs, rhs, options) {
               formatter,
               recursor,
               decreaseIndent: formatter.increaseIndent,
-              shouldFormat: formatter.shouldFormat || alwaysFormat,
+              shouldFormat: builder === lineBuilder
+                ? itemAndPropertyLimit.wrap(formatter.shouldFormat || alwaysFormat, limits)
+                : formatter.shouldFormat || alwaysFormat,
               subject,
             })
             formatIndex++
@@ -278,6 +288,7 @@ function diffDescriptors (lhs, rhs, options) {
             decreaseIndent: formatter.increaseIndent,
             exceedsMaxDepth: formatter.increaseIndent && maxDepth > 0 && indent.level >= maxDepth,
             shouldFormat: formatter.shouldFormat || alwaysFormat,
+            shouldFormatEqual: itemAndPropertyLimit.wrap(formatter.shouldFormat || alwaysFormat, limits),
           })
           diffIndex++
 
@@ -289,6 +300,7 @@ function diffDescriptors (lhs, rhs, options) {
             decreaseIndent: formatter.increaseIndent,
             exceedsMaxDepth: formatter.increaseIndent && maxDepth > 0 && indent.level >= maxDepth,
             shouldFormat: formatter.shouldFormat || alwaysFormat,
+            shouldFormatEqual: itemAndPropertyLimit.wrap(formatter.shouldFormat || alwaysFormat, limits),
             subject: lhs,
           })
           diffIndex++

--- a/lib/format.js
+++ b/lib/format.js
@@ -3,6 +3,7 @@
 const Circular = require('./Circular')
 const Indenter = require('./Indenter')
 const describe = require('./describe')
+const itemAndPropertyLimit = require('./itemAndPropertyLimit')
 const lineBuilder = require('./lineBuilder')
 const themeUtils = require('./themeUtils')
 
@@ -18,6 +19,7 @@ function formatDescriptor (subject, options) {
 
   const circular = new Circular()
   const maxDepth = (options && options.maxDepth) || 0
+  const limits = itemAndPropertyLimit.normalize(options)
 
   let indent = fixedIndent
 
@@ -57,7 +59,7 @@ function formatDescriptor (subject, options) {
             formatter,
             recursor,
             decreaseIndent: formatter.increaseIndent,
-            shouldFormat: formatter.shouldFormat || alwaysFormat,
+            shouldFormat: itemAndPropertyLimit.wrap(formatter.shouldFormat || alwaysFormat, limits),
             subject,
           })
           topIndex++

--- a/lib/itemAndPropertyLimit.js
+++ b/lib/itemAndPropertyLimit.js
@@ -1,0 +1,44 @@
+'use strict'
+
+function normalizeLimit (value) {
+  return Number.isInteger(value) && value >= 0
+    ? value
+    : Infinity
+}
+
+function normalize (options) {
+  return {
+    maxItems: normalizeLimit(options && options.maxItems),
+    maxProperties: normalizeLimit(options && options.maxProperties),
+  }
+}
+
+function wrap (shouldFormat, limits) {
+  if (limits.maxItems === Infinity && limits.maxProperties === Infinity) {
+    return shouldFormat
+  }
+
+  let itemCount = 0
+  let propertyCount = 0
+
+  return subject => {
+    if (!shouldFormat(subject)) return false
+
+    if (subject.isItem === true) {
+      if (itemCount >= limits.maxItems) return false
+      itemCount++
+      return true
+    }
+
+    if (subject.isProperty === true) {
+      if (propertyCount >= limits.maxProperties) return false
+      propertyCount++
+      return true
+    }
+
+    return true
+  }
+}
+
+exports.normalize = normalize
+exports.wrap = wrap

--- a/test/item-and-property-limits.js
+++ b/test/item-and-property-limits.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const test = require('ava')
+const concordance = require('..')
+
+test('format() respects maxItems option', t => {
+  const result = concordance.format([1, 2, 3, 4, 5], {
+    maxItems: 2,
+  })
+
+  t.true(result.includes('1,'))
+  t.true(result.includes('2,'))
+  t.false(result.includes('3,'))
+  t.false(result.includes('4,'))
+  t.false(result.includes('5,'))
+})
+
+test('format() respects maxProperties option', t => {
+  const result = concordance.format({
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4,
+    e: 5,
+  }, {
+    maxProperties: 2,
+  })
+
+  t.true(result.includes('a: 1,'))
+  t.true(result.includes('b: 2,'))
+  t.false(result.includes('c: 3,'))
+  t.false(result.includes('d: 4,'))
+  t.false(result.includes('e: 5,'))
+})
+
+test('diff() limits equal nested items and properties', t => {
+  const result = concordance.diff({
+    changed: 1,
+    equalObject: {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+    },
+    equalArray: [1, 2, 3, 4, 5],
+  }, {
+    changed: 999,
+    equalObject: {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+    },
+    equalArray: [1, 2, 3, 4, 5],
+  }, {
+    maxProperties: 2,
+    maxItems: 2,
+  })
+
+  t.true(result.includes('-   changed: 1,'))
+  t.true(result.includes('+   changed: 999,'))
+  t.true(result.includes('equalArray: ['))
+  t.true(result.includes('      1,'))
+  t.true(result.includes('      2,'))
+  t.false(result.includes('      3,'))
+  t.false(result.includes('      4,'))
+  t.false(result.includes('      5,'))
+  t.true(result.includes('equalObject: {'))
+  t.true(result.includes('      a: 1,'))
+  t.true(result.includes('      b: 2,'))
+  t.false(result.includes('      c: 3,'))
+  t.false(result.includes('      d: 4,'))
+  t.false(result.includes('      e: 5,'))
+})


### PR DESCRIPTION
Adds maxItems and maxProperties options to limit how many list items and object properties are formatted.

These limits are also applied to equal nested parts when diffing, while preserving the actual differing values.

Tests were added for:
- format() with maxItems
- format() with maxProperties
- diff() limiting equal nested items/properties without hiding differences

Fixes #12


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#12: Allow number of properties / items shown to be controlled](https://oss.issuehunt.io/repos/87210037/issues/12)
---
</details>
<!-- /Issuehunt content-->