### PR TITLE
Escape invisible string characters

### DIFF
--- a/lib/primitiveValues/string.js
+++ b/lib/primitiveValues/string.js
@@ -20,11 +20,71 @@ exports.deserialize = describe
 const tag = Symbol('StringValue')
 exports.tag = tag
 
-// TODO: Escape invisible characters (e.g. zero-width joiner, non-breaking space),
-// ambiguous characters (other kinds of spaces, combining characters). Use
-// http://graphemica.com/blocks/control-pictures where applicable.
+const SIMPLE_ESCAPES = new Map([
+  ['\b', '\\b'],
+  ['\t', '\\t'],
+  ['\v', '\\v'],
+  ['\f', '\\f'],
+])
+
+function unicodeEscape (character) {
+  const codePoint = character.codePointAt(0)
+  if (codePoint <= 0xFFFF) {
+    return '\\u' + codePoint.toString(16).toUpperCase().padStart(4, '0')
+  }
+
+  return '\\u{' + codePoint.toString(16).toUpperCase() + '}'
+}
+
+function escapeCharacter (character) {
+  return SIMPLE_ESCAPES.get(character) || unicodeEscape(character)
+}
+
+function isEscapableCodePoint (codePoint) {
+  return codePoint <= 0x09 ||
+    codePoint === 0x0B ||
+    codePoint === 0x0C ||
+    (codePoint >= 0x0E && codePoint <= 0x1F) ||
+    (codePoint >= 0x7F && codePoint <= 0xA0) ||
+    codePoint === 0xAD ||
+    (codePoint >= 0x300 && codePoint <= 0x36F) ||
+    codePoint === 0x1680 ||
+    codePoint === 0x180E ||
+    (codePoint >= 0x1AB0 && codePoint <= 0x1AFF) ||
+    (codePoint >= 0x1DC0 && codePoint <= 0x1DFF) ||
+    (codePoint >= 0x2000 && codePoint <= 0x200F) ||
+    (codePoint >= 0x2028 && codePoint <= 0x202F) ||
+    (codePoint >= 0x205F && codePoint <= 0x206F) ||
+    (codePoint >= 0x20D0 && codePoint <= 0x20FF) ||
+    codePoint === 0x3000 ||
+    (codePoint >= 0xFE00 && codePoint <= 0xFE0F) ||
+    (codePoint >= 0xFE20 && codePoint <= 0xFE2F) ||
+    codePoint === 0xFEFF
+}
+
+function isEscapableCharacter (character) {
+  return isEscapableCodePoint(character.codePointAt(0))
+}
+
+function hasEscapableCharacters (string) {
+  for (const character of string) {
+    if (isEscapableCharacter(character)) return true
+  }
+
+  return false
+}
+
 function basicEscape (string) {
-  return string.replace(/\\/g, '\\\\')
+  let escaped = ''
+  for (const character of string) {
+    if (character === '\\') {
+      escaped += '\\\\'
+    } else {
+      escaped += isEscapableCharacter(character) ? escapeCharacter(character) : character
+    }
+  }
+
+  return escaped
 }
 
 const CRLF_CONTROL_PICTURE = '\u240D\u240A'
@@ -167,7 +227,7 @@ class StringValue {
 
   formatAsKey (theme) {
     const key = this.value
-    if (keyword.isIdentifierNameES6(key, true) || String(parseInt(key, 10)) === key) {
+    if ((keyword.isIdentifierNameES6(key, true) || String(parseInt(key, 10)) === key) && !hasEscapableCharacters(key)) {
       return key
     }
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -73,6 +73,12 @@ test('diffs single line strings', t => {
   t.snapshot(actual2)
 })
 
+test('diffs escaped invisible and ambiguous characters in strings', t => {
+  const noBreakSpace = String.fromCharCode(0xA0)
+
+  t.is(concordance.diff(`a${noBreakSpace}b`, 'a b'), "- 'a\\u00A0b'\n+ 'a b'")
+})
+
 test('diffs multiline strings', t => {
   const actual1 = diff('foo\nbar', 'baz\nbar')
   t.snapshot(actual1)

--- a/test/format.js
+++ b/test/format.js
@@ -104,6 +104,28 @@ test('escapes backticks in multi-line strings with the default theme', t => {
   t.snapshot(_format('`\n'), 'should be escaped')
 })
 
+test('escapes invisible and ambiguous characters in strings', t => {
+  const values = [
+    [`a${String.fromCharCode(0x09)}b`, "'a\\tb'"],
+    [`a${String.fromCharCode(0xA0)}b`, "'a\\u00A0b'"],
+    [`a${String.fromCharCode(0x200D)}b`, "'a\\u200Db'"],
+    [`e${String.fromCharCode(0x301)}`, "'e\\u0301'"],
+    [`a${String.fromCharCode(0x1B)}[31mb`, "'a\\u001B[31mb'"],
+  ]
+
+  for (const [value, expected] of values) {
+    t.is(_format(value), expected)
+  }
+})
+
+test('escapes invisible characters before formatting strings as keys', t => {
+  const key = `a${String.fromCharCode(0x200D)}b`
+
+  t.is(_format({ [key]: 'value' }), `{
+  'a\\u200Db': 'value',
+}`)
+})
+
 test('formats a simple object', t => {
   const obj = { foo: 'bar', baz: 'qux' }
   const actual = format(obj)


### PR DESCRIPTION
Fixes #4.\n\nThis escapes invisible and ambiguous characters while formatting strings, including control characters, non-breaking and alternate spaces, zero-width characters, combining marks, variation selectors, and ANSI escape initiators. Existing line break rendering is preserved so multiline strings still use control pictures.\n\nTests:\n- npx -y node@14 node_modules/.bin/as-i-preach\n- npx -y node@14 node_modules/.bin/c8 node_modules/.bin/ava


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#4: Escape or replace invisible or ambiguous characters when formatting strings](https://oss.issuehunt.io/repos/87210037/issues/4)
---
</details>
<!-- /Issuehunt content-->