### PR TITLE
test: cover getter descriptor behavior

### DIFF
--- a/test/getters.js
+++ b/test/getters.js
@@ -38,6 +38,16 @@ test('formatDescriptor() reuses the first getter value for a descriptor', t => {
   t.is(subject.callCount, 1)
 })
 
+test('compareDescriptors() reuses the first getter value for a descriptor', t => {
+  const subject = objectWithGetter([1, 2])
+  const descriptor = concordance.describe(subject.object)
+
+  t.true(concordance.compareDescriptors(descriptor, concordance.describe({ value: 1 })))
+  t.false(concordance.compareDescriptors(descriptor, concordance.describe({ value: 2 })))
+  t.regex(concordance.formatDescriptor(descriptor), /value: 1/)
+  t.is(subject.callCount, 1)
+})
+
 test('compareDescriptors() reuses the first getter value after formatting', t => {
   const subject = objectWithGetter([1, 2])
   const descriptor = concordance.describe(subject.object)

--- a/test/getters.js
+++ b/test/getters.js
@@ -1,0 +1,49 @@
+const test = require('ava')
+
+const concordance = require('..')
+
+function objectWithGetter (values) {
+  let callCount = 0
+  const object = {}
+
+  Object.defineProperty(object, 'value', {
+    enumerable: true,
+    get () {
+      return values[callCount++]
+    },
+  })
+
+  return {
+    object,
+    get callCount () {
+      return callCount
+    },
+  }
+}
+
+test('compare() invokes object property getters', t => {
+  const subject = objectWithGetter(['actual'])
+
+  t.true(concordance.compare(subject.object, { value: 'actual' }).pass)
+  t.is(subject.callCount, 1)
+})
+
+test('formatDescriptor() reuses the first getter value for a descriptor', t => {
+  const subject = objectWithGetter([1, 2, 3])
+  const descriptor = concordance.describe(subject.object)
+
+  t.is(subject.callCount, 0)
+  t.regex(concordance.formatDescriptor(descriptor), /value: 1/)
+  t.regex(concordance.formatDescriptor(descriptor), /value: 1/)
+  t.is(subject.callCount, 1)
+})
+
+test('compareDescriptors() reuses the first getter value after formatting', t => {
+  const subject = objectWithGetter([1, 2])
+  const descriptor = concordance.describe(subject.object)
+
+  t.regex(concordance.formatDescriptor(descriptor), /value: 1/)
+  t.true(concordance.compareDescriptors(descriptor, concordance.describe({ value: 1 })))
+  t.false(concordance.compareDescriptors(descriptor, concordance.describe({ value: 2 })))
+  t.is(subject.callCount, 1)
+})


### PR DESCRIPTION
Refs #2

IssueHunt bounty: https://issuehunt.io/r/concordancejs/concordance/issues/2

## What changed
- Added regression coverage for enumerable object getters.
- Verifies compare() invokes getters when comparing object properties.
- Verifies formatDescriptor() reuses the first getter value for a descriptor across repeated formatting.
- Verifies compareDescriptors() keeps using that first cached getter value after formatting.

## Why
The funded issue asks that getters are invoked when comparing / formatting, and that a descriptor reused across operations keeps the first value it got from the getter. Current main already has the intended runtime behavior; this PR makes that behavior explicit and protects it from regression.

## Test evidence
- `PATH=/Users/nicdunz/.nvm/versions/node/v16.20.2/bin:$PATH npx ava test/getters.js`
- `PATH=/Users/nicdunz/.nvm/versions/node/v16.20.2/bin:$PATH npm test` -> 299 tests passed
- `git diff --check -- test/getters.js`


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2: Handle edge-cases involving getters](https://oss.issuehunt.io/repos/87210037/issues/2)
---
</details>
<!-- /Issuehunt content-->