### PR TITLE
test: cover getStringTag promise fallback

### DIFF
--- a/test/encoder.js
+++ b/test/encoder.js
@@ -1,0 +1,24 @@
+const test = require('ava')
+
+const encoder = require('../lib/encoder')
+
+test('encode rejects unsupported state values', t => {
+  const error = t.throws(() => {
+    encoder.encode(1, {
+      children: [],
+      id: 1,
+      pluginIndex: 0,
+      state: {},
+    }, new Map())
+  }, { instanceOf: TypeError })
+
+  t.is(error.message, 'Unexpected value with type 0xOBJECT')
+})
+
+test('decodePlugins rejects unsupported value types', t => {
+  const error = t.throws(() => {
+    encoder.decodePlugins(Buffer.from([0xFF]))
+  }, { instanceOf: TypeError })
+
+  t.is(error.message, 'Could not decode type 0xFF')
+})

--- a/test/getStringTag.js
+++ b/test/getStringTag.js
@@ -1,0 +1,46 @@
+const test = require('ava')
+
+const getStringTagPath = require.resolve('../lib/getStringTag')
+
+function requireWithPromiseStringTag (value, assertions) {
+  const descriptor = Object.getOwnPropertyDescriptor(Promise.prototype, Symbol.toStringTag)
+
+  // eslint-disable-next-line no-extend-native
+  Object.defineProperty(Promise.prototype, Symbol.toStringTag, {
+    configurable: true,
+    value,
+  })
+  delete require.cache[getStringTagPath]
+
+  try {
+    assertions(require('../lib/getStringTag'))
+  } finally {
+    if (descriptor) {
+      // eslint-disable-next-line no-extend-native
+      Object.defineProperty(Promise.prototype, Symbol.toStringTag, descriptor)
+    } else {
+      delete Promise.prototype[Symbol.toStringTag]
+    }
+    delete require.cache[getStringTagPath]
+  }
+}
+
+test('detects promises when their native string tag is Object', t => {
+  requireWithPromiseStringTag('Object', getStringTag => {
+    t.is(Object.prototype.toString.call(Promise.resolve()), '[object Object]')
+    t.is(getStringTag(Promise.resolve()), 'Promise')
+  })
+})
+
+test('uses the native string tag when promises are reported correctly', t => {
+  const getStringTag = require('../lib/getStringTag')
+  t.is(getStringTag(Promise.resolve()), 'Promise')
+})
+
+test('does not mistake plain objects for promises in string tag workaround', t => {
+  requireWithPromiseStringTag('Object', getStringTag => {
+    t.is(getStringTag({}), 'Object')
+    t.is(getStringTag(Object.create(null)), 'Object')
+    t.is(getStringTag({ constructor: 42 }), 'Object')
+  })
+})


### PR DESCRIPTION
Refs #1

This adds focused coverage for two previously under-covered internal helpers:

- `lib/getStringTag`: simulates an environment where native promises report `[object Object]`, verifies the Promise fallback, covers the native Promise tag path, and guards against mistaking plain objects for promises.
- `lib/encoder`: covers unsupported encode/decode value error paths.

Coverage impact:
- `lib/getStringTag.js` is now 100% statements / branches / functions / lines under the targeted test run.
- `lib/encoder.js` gains direct coverage for both unsupported-value error branches.

Validation:
- `npx c8 --reporter=text ava test/encoder.js test/getStringTag.js` passes: 5 tests.
- `npx c8 --reporter=text ava` passes: 301 tests.
- `npx -p node@14 -c "node node_modules/@novemberborn/eslint-plugin-as-i-preach/cli.js && node node_modules/c8/bin/c8.js node_modules/ava/cli.js"` passes: 301 tests, with only the repo's pre-existing `no-warning-comments` warnings.

Note: running `npm test` directly on the local Node 24 runtime fails before tests run because this legacy ESLint/plugin stack calls removed Node APIs. The Node 14 command above matches the package engines and verifies lint plus tests.