### PR TITLE
test: cover boxed value serialization

### DIFF
--- a/test/serialize-and-encode.js
+++ b/test/serialize-and-encode.js
@@ -94,6 +94,9 @@ if (typeof BigInt === 'function') {
 // Objects
 test('object with primitive property', useDeserialized, { foo: 'bar' })
 test('object with complex property', useDeserialized, { foo: {} })
+test('boxed string', useDeserialized, new Object('foo'))
+test('boxed number', useDeserialized, new Object(42))
+test('boxed boolean', useDeserialized, new Object(true))
 test('object with well known symbol key', useDeserialized, { [Symbol.unscopables]: 'bar' })
 test('object with registered symbol key', useDeserialized, { [Symbol.for('foo')]: 'bar' })
 test('object with arbitrary symbol key', useDeserialized, { [Symbol('foo')]: 'bar' })


### PR DESCRIPTION
## Summary
- Add serialization round-trip coverage for boxed string, number, and boolean values
- This covers the boxed value descriptor serialization path and brings `lib/complexValues/boxed.js` to full line/function coverage

## Verification
- `npx ava test/serialize-and-encode.js`
- `npm test`
- `npx c8 report --reporter=text`

Part of #1.