### PR TITLE
Fix Promise descriptor deserialization

### DIFF
--- a/lib/complexValues/promise.js
+++ b/lib/complexValues/promise.js
@@ -11,8 +11,8 @@ function describe (props) {
 }
 exports.describe = describe
 
-function deserialize (props) {
-  return new DeserializedPromiseValue(props)
+function deserialize (props, recursor) {
+  return new DeserializedPromiseValue(props, recursor)
 }
 exports.deserialize = deserialize
 

--- a/test/serialize-and-encode.js
+++ b/test/serialize-and-encode.js
@@ -200,6 +200,11 @@ test('compare deserialized function with object', t => {
 test('generator function', useDeserialized, function * foo () {})
 test('global', useDeserialized, global)
 test('promise', useDeserialized, Promise.resolve())
+{
+  const promise = Promise.resolve()
+  promise.extra = 'value'
+  test('promise with extra property', useDeserialized, promise)
+}
 test('regexp', useDeserialized, /foo/gi)
 
 test('plugin', useDeserialized, new customErrorPlugin.CustomError('custom error', 'PLUGIN', 1), { plugins })


### PR DESCRIPTION
Summary:
- pass the recursor through when deserializing Promise descriptors
- add a regression test for Promise values with enumerable properties

The serializer already records enumerable Promise properties. During deserialization the Promise descriptor was being rebuilt without the recursor, so those properties could not be replayed after a round trip.

Tests:
- npm test, run with Node 14.21.3

Related to #1.
