### PR TITLE
test: cover expected-only circular references

### DIFF
--- a/test/compare.js
+++ b/test/compare.js
@@ -54,6 +54,15 @@ test('survives odd circular references', t => {
   t.false(compare(foo, foo2).pass)
 })
 
+test('detects circular references only on expected side', t => {
+  const expected = {}
+  expected.self = expected
+
+  const actual = { self: {} }
+
+  t.false(compare(actual, expected).pass)
+})
+
 test('arrays are also compared by property', t => {
   const a1 = [1, 2, 3]
   a1.p = 'a1'


### PR DESCRIPTION
Refs #1.

## Summary
- add regression coverage for comparing an expected-side circular reference against a non-circular actual value
- covers the remaining asymmetric circular-reference branch in compare descriptor traversal

## Verification
- `npx --yes --package=node@16 --call "./node_modules/.bin/ava test/compare.js"`
- `npx --yes --package=node@16 --call "npm test"`