### PR TITLE
test: cover map and set extra property serialization

### DIFF
--- a/test/serialize-and-encode.js
+++ b/test/serialize-and-encode.js
@@ -141,10 +141,20 @@ test('map with primitive key and value', useDeserialized, new Map([['foo', 'bar'
 test('map with complex key and primitive value', useDeserialized, new Map([[{}, 'bar']]))
 test('map with complex key and value', useDeserialized, new Map([[{}, {}]]))
 test('map with primitive key and complex value', useDeserialized, new Map([['foo', {}]]))
+{
+  const map = new Map([['foo', 'bar']])
+  map.extra = { baz: 'qux' }
+  test('map with additional property', useDeserialized, map)
+}
 
 // Sets
 test('set with primitive value', useDeserialized, new Set(['foo']))
 test('set with complex value', useDeserialized, new Set([{}]))
+{
+  const set = new Set(['foo'])
+  set.extra = { baz: 'qux' }
+  test('set with additional property', useDeserialized, set)
+}
 
 // Pointers
 {


### PR DESCRIPTION
## Summary
- add serialization/deserialization round-trip coverage for Maps with extra enumerable properties
- add the same coverage for Sets with extra enumerable properties

## Tests
- `npx ava test/serialize-and-encode.js --match='*additional property*'`
- `npm test`

Contributes to #1.