### PR TITLE
test: cover symbol descriptor comparisons

### DIFF
--- a/test/compare.js
+++ b/test/compare.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 
+const { compareDescriptors, describe } = require('..')
 const { compare } = require('../lib/compare')
 
 test('compare functions by reference', t => {
@@ -34,6 +35,17 @@ test('objects compare even if symbol properties are out of order', t => {
   a2[s1] = 1
 
   t.true(compare(a1, a2).pass)
+})
+
+test('compares registered symbols by global key', t => {
+  t.true(compareDescriptors(describe(Symbol.for('shared')), describe(Symbol.for('shared'))))
+  t.false(compareDescriptors(describe(Symbol.for('shared')), describe(Symbol.for('other'))))
+  t.false(compareDescriptors(describe(Symbol.for('shared')), describe(Symbol('shared'))))
+})
+
+test('compares well-known symbols by identity label', t => {
+  t.true(compareDescriptors(describe(Symbol.iterator), describe(Symbol.iterator)))
+  t.false(compareDescriptors(describe(Symbol.iterator), describe(Symbol.asyncIterator)))
 })
 
 test('-0 is not equal to +0', t => {


### PR DESCRIPTION
Refs #1

IssueHunt bounty: https://oss.issuehunt.io/r/concordancejs/concordance/issues/1

## Summary
- add direct descriptor comparison coverage for registered symbols, including same-key and different-key comparisons
- add direct descriptor comparison coverage for well-known symbols with same-label and different-label cases
- cover the `SymbolValue.compare()` path for symbols that have stable string comparison keys

## Coverage
- `lib/primitiveValues/symbol.js` improves from 96.49% statements / 96.49% lines to 100% statements / 100% lines
- overall coverage improves from 96.22% to 96.30% statements/lines

## Verification
- `npx -p node@14 -c "node node_modules/ava/cli.js test/compare.js"` -> 9 tests passed
- `npx -p node@14 -c "node node_modules/@novemberborn/eslint-plugin-as-i-preach/cli.js && node node_modules/c8/bin/c8.js node_modules/ava/cli.js"` -> 298 tests passed
- `npx -p node@14 -c "node node_modules/c8/bin/c8.js report --reporter=text"`
- `git diff --check`
