### PR TITLE
test: add Circular and themeUtils coverage for helper behavior

### DIFF
--- a/test/circular.js
+++ b/test/circular.js
@@ -1,0 +1,54 @@
+const test = require('ava')
+
+const Circular = require('../lib/Circular')
+
+test('tracks descriptors in insertion order', t => {
+  const stack = new Circular()
+  const first = { label: 'first' }
+  const second = { label: 'second' }
+
+  stack.add(first).add(second)
+
+  t.true(stack.has(first))
+  t.true(stack.has(second))
+  t.is(stack.get(first), 1)
+  t.is(stack.get(second), 2)
+})
+
+test('does not track item, map-entry and property descriptors', t => {
+  const stack = new Circular()
+  const item = { isItem: true }
+  const mapEntry = { isMapEntry: true }
+  const property = { isProperty: true }
+
+  stack.add(item).add(mapEntry).add(property)
+
+  t.false(stack.has(item))
+  t.false(stack.has(mapEntry))
+  t.false(stack.has(property))
+  t.is(stack.get(item), 0)
+  t.is(stack.get(mapEntry), 0)
+  t.is(stack.get(property), 0)
+})
+
+test('throws if descriptor is added twice', t => {
+  const stack = new Circular()
+  const descriptor = { label: 'duplicate' }
+
+  stack.add(descriptor)
+
+  const error = t.throws(() => stack.add(descriptor))
+  t.is(error.message, 'Already in stack')
+})
+
+test('throws if deleting descriptor that is not on top of stack', t => {
+  const stack = new Circular()
+  const first = { label: 'first' }
+  const second = { label: 'second' }
+
+  stack.add(first).add(second)
+
+  const error = t.throws(() => stack.delete(first))
+  t.is(error.message, 'Not on top of stack')
+})
+

--- a/test/theme-utils.js
+++ b/test/theme-utils.js
@@ -1,0 +1,63 @@
+const test = require('ava')
+
+const {
+  normalize,
+  addModifier,
+  applyModifiers,
+  applyModifiersToOriginal,
+} = require('../lib/themeUtils')
+
+test('normalize() returns cached theme for same custom theme object', t => {
+  const themeOverride = { number: { open: '<', close: '>' } }
+  const first = normalize({ theme: themeOverride })
+  const second = normalize({ theme: themeOverride })
+
+  t.is(first, second)
+  t.is(first.number.open, '<')
+  t.is(first.number.close, '>')
+})
+
+test('applyModifiers() applies and caches transformed themes', t => {
+  const descriptor = {}
+  const baseTheme = normalize()
+
+  const wrapNumber = theme => {
+    theme.number.open = '['
+    theme.number.close = ']'
+  }
+
+  addModifier(descriptor, wrapNumber)
+  const first = applyModifiers(descriptor, baseTheme)
+  const second = applyModifiers(descriptor, baseTheme)
+
+  t.not(first, baseTheme)
+  t.is(first, second)
+  t.is(first.number.open, '[')
+  t.is(first.number.close, ']')
+  t.is(baseTheme.number.open, '')
+  t.is(baseTheme.number.close, '')
+})
+
+test('applyModifiersToOriginal() reuses unmodified theme as source', t => {
+  const descriptor = {}
+  const baseTheme = normalize()
+
+  addModifier(descriptor, theme => {
+    theme.boolean.open = '<b>'
+    theme.boolean.close = '</b>'
+  })
+  const onceModified = applyModifiers(descriptor, baseTheme)
+
+  addModifier(descriptor, theme => {
+    theme.symbol.open = '<s>'
+    theme.symbol.close = '</s>'
+  })
+
+  const fromOriginal = applyModifiersToOriginal(descriptor, onceModified)
+  const direct = applyModifiers(descriptor, baseTheme)
+
+  t.is(fromOriginal, direct)
+  t.is(fromOriginal.boolean.open, '<b>')
+  t.is(fromOriginal.symbol.open, '<s>')
+})
+


### PR DESCRIPTION
## Summary
- Add focused regression tests for `lib/Circular` stack behavior:
  - insertion order tracking for non-structural descriptors
  - skip-tracking for wrapper descriptors (`isItem`, `isMapEntry`, `isProperty`)
  - explicit error-path coverage for duplicate add and invalid delete order
- Add focused tests for `lib/themeUtils` modifier pipeline:
  - `normalize()` cache behavior for repeated custom theme objects
  - `applyModifiers()` transformed-theme caching and immutability of base theme
  - `applyModifiersToOriginal()` behavior when reapplying modifiers from a modified theme

## Why this helps issue #1
Issue #1 asks for broader coverage to reduce hidden logic bugs. These tests directly target internal helper paths and cache semantics that are easy to regress and were previously under-covered.

## Validation
- `npx ava test/circular.js test/theme-utils.js`
