### PR TITLE
Add item and property output limits

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -4,6 +4,7 @@ const Circular = require('./Circular')
 const Indenter = require('./Indenter')
 const constants = require('./constants')
 const describe = require('./describe')
+const formatLimits = require('./formatLimits')
 const lineBuilder = require('./lineBuilder')
 const recursorUtils = require('./recursorUtils')
 const shouldCompareDeep = require('./shouldCompareDeep')
@@ -58,6 +59,7 @@ function compareComplexShape (lhs, rhs) {
 function diffDescriptors (lhs, rhs, options) {
   const theme = themeUtils.normalize(options)
   const invert = options ? options.invert === true : false
+  const limits = formatLimits.createLimits(options)
 
   const lhsCircular = new Circular()
   const rhsCircular = new Circular()
@@ -79,7 +81,7 @@ function diffDescriptors (lhs, rhs, options) {
     if (diffIndex >= 0 && !diffStack[diffIndex].shouldFormat(subject)) return
 
     if (circular.has(subject)) {
-      diffStack[diffIndex].formatter.append(builder.single(theme.circular))
+      formatLimits.append(diffStack[diffIndex], builder.single(theme.circular), subject, theme, limits)
       return
     }
 
@@ -88,7 +90,7 @@ function diffDescriptors (lhs, rhs, options) {
 
     do {
       if (circular.has(subject)) {
-        formatStack[formatIndex].formatter.append(builder.single(theme.circular), subject)
+        formatLimits.append(formatStack[formatIndex], builder.single(theme.circular), subject, theme, limits)
       } else {
         let didFormat = false
         if (typeof subject.formatDeep === 'function') {
@@ -101,10 +103,10 @@ function diffDescriptors (lhs, rhs, options) {
               if (diffIndex === -1) {
                 buffer.append(formatted)
               } else {
-                diffStack[diffIndex].formatter.append(formatted, subject)
+                formatLimits.append(diffStack[diffIndex], formatted, subject, theme, limits)
               }
             } else {
-              formatStack[formatIndex].formatter.append(formatted, subject)
+              formatLimits.append(formatStack[formatIndex], formatted, subject, theme, limits)
             }
           }
         }
@@ -121,9 +123,9 @@ function diffDescriptors (lhs, rhs, options) {
 
             if (formatIndex === -1) {
               formatted = builder.setDefaultGutter(formatted)
-              diffStack[diffIndex].formatter.append(formatted, subject)
+              formatLimits.append(diffStack[diffIndex], formatted, subject, theme, limits)
             } else {
-              formatStack[formatIndex].formatter.append(formatted, subject)
+              formatLimits.append(formatStack[formatIndex], formatted, subject, theme, limits)
             }
           } else {
             formatStack.push({
@@ -131,6 +133,7 @@ function diffDescriptors (lhs, rhs, options) {
               recursor,
               decreaseIndent: formatter.increaseIndent,
               shouldFormat: formatter.shouldFormat || alwaysFormat,
+              limitState: formatLimits.createState(),
               subject,
             })
             formatIndex++
@@ -161,10 +164,10 @@ function diffDescriptors (lhs, rhs, options) {
           if (diffIndex === -1) {
             buffer.append(formatted)
           } else {
-            diffStack[diffIndex].formatter.append(formatted, record.subject)
+            formatLimits.append(diffStack[diffIndex], formatted, record.subject, theme, limits)
           }
         } else {
-          formatStack[formatIndex].formatter.append(formatted, record.subject)
+          formatLimits.append(formatStack[formatIndex], formatted, record.subject, theme, limits)
         }
       }
     } while (formatIndex >= 0)
@@ -278,6 +281,7 @@ function diffDescriptors (lhs, rhs, options) {
             decreaseIndent: formatter.increaseIndent,
             exceedsMaxDepth: formatter.increaseIndent && maxDepth > 0 && indent.level >= maxDepth,
             shouldFormat: formatter.shouldFormat || alwaysFormat,
+            limitState: formatLimits.createState(),
           })
           diffIndex++
 
@@ -289,6 +293,7 @@ function diffDescriptors (lhs, rhs, options) {
             decreaseIndent: formatter.increaseIndent,
             exceedsMaxDepth: formatter.increaseIndent && maxDepth > 0 && indent.level >= maxDepth,
             shouldFormat: formatter.shouldFormat || alwaysFormat,
+            limitState: formatLimits.createState(),
             subject: lhs,
           })
           diffIndex++
@@ -314,7 +319,7 @@ function diffDescriptors (lhs, rhs, options) {
           if (diffIndex === -1) {
             buffer.append(diffed)
           } else {
-            diffStack[diffIndex].formatter.append(diffed, lhs)
+            formatLimits.append(diffStack[diffIndex], diffed, lhs, theme, limits)
           }
         }
       }
@@ -356,7 +361,7 @@ function diffDescriptors (lhs, rhs, options) {
           if (diffIndex === -1) {
             buffer.append(formatted)
           } else {
-            diffStack[diffIndex].formatter.append(formatted, record.subject)
+            formatLimits.append(diffStack[diffIndex], formatted, record.subject, theme, limits)
           }
         }
       } else {

--- a/lib/format.js
+++ b/lib/format.js
@@ -3,6 +3,7 @@
 const Circular = require('./Circular')
 const Indenter = require('./Indenter')
 const describe = require('./describe')
+const formatLimits = require('./formatLimits')
 const lineBuilder = require('./lineBuilder')
 const themeUtils = require('./themeUtils')
 
@@ -18,6 +19,7 @@ function formatDescriptor (subject, options) {
 
   const circular = new Circular()
   const maxDepth = (options && options.maxDepth) || 0
+  const limits = formatLimits.createLimits(options)
 
   let indent = fixedIndent
 
@@ -27,7 +29,7 @@ function formatDescriptor (subject, options) {
 
   do {
     if (circular.has(subject)) {
-      stack[topIndex].formatter.append(lineBuilder.single(theme.circular), subject)
+      formatLimits.append(stack[topIndex], lineBuilder.single(theme.circular), subject, theme, limits)
     } else {
       let didFormat = false
       if (typeof subject.formatDeep === 'function') {
@@ -37,7 +39,7 @@ function formatDescriptor (subject, options) {
           if (topIndex === -1) {
             buffer.append(formatted)
           } else {
-            stack[topIndex].formatter.append(formatted, subject)
+            formatLimits.append(stack[topIndex], formatted, subject, theme, limits)
           }
         }
       }
@@ -51,13 +53,14 @@ function formatDescriptor (subject, options) {
           const formatted = !isEmpty && typeof formatter.maxDepth === 'function'
             ? formatter.maxDepth()
             : formatter.finalize()
-          stack[topIndex].formatter.append(formatted, subject)
+          formatLimits.append(stack[topIndex], formatted, subject, theme, limits)
         } else {
           stack.push({
             formatter,
             recursor,
             decreaseIndent: formatter.increaseIndent,
             shouldFormat: formatter.shouldFormat || alwaysFormat,
+            limitState: formatLimits.createState(),
             subject,
           })
           topIndex++
@@ -86,7 +89,7 @@ function formatDescriptor (subject, options) {
       if (topIndex === -1) {
         buffer.append(formatted)
       } else {
-        stack[topIndex].formatter.append(formatted, record.subject)
+        formatLimits.append(stack[topIndex], formatted, record.subject, theme, limits)
       }
     }
   } while (topIndex >= 0)

--- a/lib/formatLimits.js
+++ b/lib/formatLimits.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const lineBuilder = require('./lineBuilder')
+const mapEntryTag = require('./metaDescriptors/mapEntry').tag
+
+const unlimited = Infinity
+
+function normalizeLimit (value) {
+  return Number.isInteger(value) && value >= 0 ? value : unlimited
+}
+
+function createLimits (options) {
+  return {
+    maxItems: normalizeLimit(options && options.maxItems),
+    maxProperties: normalizeLimit(options && options.maxProperties),
+  }
+}
+exports.createLimits = createLimits
+
+function createState () {
+  return {
+    items: 0,
+    itemsTruncated: false,
+    properties: 0,
+    propertiesTruncated: false,
+  }
+}
+exports.createState = createState
+
+function getKind (origin) {
+  if (!origin || origin.isStats === true) return null
+  if (origin.isProperty === true) return 'properties'
+  if (origin.isItem === true || origin.tag === mapEntryTag) return 'items'
+  return null
+}
+
+function getLimit (limits, kind) {
+  return kind === 'properties' ? limits.maxProperties : limits.maxItems
+}
+
+function getAfter (theme, origin, kind) {
+  if (origin && origin.tag === mapEntryTag) return theme.mapEntry.after
+  return kind === 'properties' ? theme.property.after : theme.item.after
+}
+
+function append (record, formatted, origin, theme, limits) {
+  const kind = getKind(origin)
+  if (kind === null || formatted.hasGutter) {
+    record.formatter.append(formatted, origin)
+    return
+  }
+
+  const limit = getLimit(limits, kind)
+  if (record.limitState[kind] < limit) {
+    record.limitState[kind]++
+    record.formatter.append(formatted, origin)
+    return
+  }
+
+  const truncatedKey = `${kind}Truncated`
+  if (!record.limitState[truncatedKey]) {
+    record.limitState[truncatedKey] = true
+    record.formatter.append(lineBuilder.single(theme.maxDepth + getAfter(theme, origin, kind)), origin)
+  }
+}
+exports.append = append

--- a/test/item-and-property-limits.js
+++ b/test/item-and-property-limits.js
@@ -1,0 +1,46 @@
+const test = require('ava')
+
+const { diff, format } = require('..')
+
+test('format() respects maxProperties', t => {
+  t.is(format({ a: 1, b: 2, c: 3 }, { maxProperties: 1 }), `{
+  a: 1,
+  …,
+}`)
+})
+
+test('format() respects maxItems', t => {
+  t.is(format([1, 2, 3], { maxItems: 1 }), `[
+  1,
+  …,
+]`)
+})
+
+test('diff() limits equal properties without hiding differences', t => {
+  t.is(diff(
+    { a: 1, b: 2, c: 3, z: 0 },
+    { a: 1, b: 2, c: 3, z: 1 },
+    { maxProperties: 1 },
+  ), `  {
+    a: 1,
+    …,
+-   z: 0,
++   z: 1,
+  }`)
+})
+
+test('diff() limits equal items without hiding differences', t => {
+  t.is(diff([1, 2, 3, 4], [1, 2, 3, 5], { maxItems: 1 }), `  [
+    1,
+    …,
+-   4,
++   5,
+  ]`)
+})
+
+test('maxItems applies to map entries', t => {
+  t.is(format(new Map([['a', 1], ['b', 2]]), { maxItems: 1 }), `Map {
+  'a' => 1,
+  …,
+}`)
+})


### PR DESCRIPTION
Fixes #12

IssueHunt bounty: https://oss.issuehunt.io/r/concordancejs/concordance/issues/12

## Summary
- add `maxItems` and `maxProperties` formatting limits for list items, map entries, and object properties
- apply the same limits to equal sections of diffs without hiding actual `+` / `-` differences
- reuse the existing `…` max-depth marker for truncated output

## Validation
- `npx ava test/item-and-property-limits.js`
- `npm test` (301 tests passed; existing no-warning-comments warnings remain)
- `git diff --check`

## Notes
There is another open PR for this issue, but this implementation keeps the truncation decision in a small shared formatter helper and explicitly avoids suppressing diff hunks with gutters.