### PR TITLE
test: cover theme normalization modifiers

### DIFF
--- a/test/themeUtils.js
+++ b/test/themeUtils.js
@@ -1,0 +1,104 @@
+const test = require('ava')
+
+const themeUtils = require('../lib/themeUtils')
+
+const noopTryDescribeValue = () => null
+
+const themePlugin = {
+  name: 'theme-utils-normalize-test',
+  apiVersion: 1,
+  theme: {
+    number: {
+      open: '(',
+    },
+    string: {
+      open: '<',
+    },
+  },
+  register: () => noopTryDescribeValue,
+}
+
+test('normalizes plugin themes with user theme overrides', t => {
+  const userTheme = {
+    number: {
+      close: ')',
+    },
+  }
+
+  const normalizedTheme = themeUtils.normalize({
+    plugins: [themePlugin],
+    theme: userTheme,
+  })
+
+  t.is(normalizedTheme.number.open, '(')
+  t.is(normalizedTheme.number.close, ')')
+  t.is(normalizedTheme.string.open, '<')
+  t.true(Object.isFrozen(normalizedTheme))
+  t.is(themeUtils.normalize({ plugins: [themePlugin], theme: userTheme }), normalizedTheme)
+
+  const pluginTheme = themeUtils.normalize({ plugins: [themePlugin] })
+  t.is(pluginTheme.number.open, '(')
+  t.is(pluginTheme.string.open, '<')
+  t.true(Object.isFrozen(pluginTheme))
+})
+
+test('applies descriptor modifiers without mutating the base theme', t => {
+  const descriptor = {}
+  const baseTheme = themeUtils.normalize()
+
+  t.is(themeUtils.applyModifiers(descriptor, baseTheme), baseTheme)
+
+  let calls = 0
+  const openModifier = theme => {
+    calls += 1
+    theme.number.open = '<'
+  }
+  const closeModifier = theme => {
+    calls += 1
+    theme.number.close = '>'
+  }
+
+  themeUtils.addModifier(descriptor, openModifier)
+  themeUtils.addModifier(descriptor, closeModifier)
+
+  const modifiedTheme = themeUtils.applyModifiers(descriptor, baseTheme)
+
+  t.not(modifiedTheme, baseTheme)
+  t.true(Object.isFrozen(modifiedTheme))
+  t.is(modifiedTheme.number.open, '<')
+  t.is(modifiedTheme.number.close, '>')
+  t.is(baseTheme.number.open, '')
+  t.is(baseTheme.number.close, '')
+  t.is(calls, 2)
+
+  t.is(themeUtils.applyModifiers(descriptor, baseTheme), modifiedTheme)
+  t.is(calls, 2)
+})
+
+test('applies later modifiers to the original theme', t => {
+  const firstDescriptor = {}
+  const secondDescriptor = {}
+  const baseTheme = themeUtils.normalize({
+    theme: {
+      number: {
+        open: '<',
+        close: '>',
+      },
+    },
+  })
+
+  themeUtils.addModifier(firstDescriptor, theme => {
+    theme.number.open = '['
+  })
+
+  const modifiedTheme = themeUtils.applyModifiers(firstDescriptor, baseTheme)
+
+  themeUtils.addModifier(secondDescriptor, theme => {
+    theme.number.close = ']'
+  })
+
+  const remodifiedTheme = themeUtils.applyModifiersToOriginal(secondDescriptor, modifiedTheme)
+
+  t.is(remodifiedTheme.number.open, '<')
+  t.is(remodifiedTheme.number.close, ']')
+})


### PR DESCRIPTION
Refs #1

IssueHunt bounty: https://issuehunt.io/r/concordancejs/concordance/issues/1

This adds focused tests for the theme normalization path in `lib/themeUtils.js`:

- plugin theme normalization with user theme overrides and cache reuse
- descriptor modifier application without mutating the base theme
- modifier cache reuse and `applyModifiersToOriginal()` behavior

I kept this separate from the other open coverage PRs, which cover function names, getStringTag, lineBuilder, serialization/encoding, and recursor helpers.

Verification:
- `npx -p node@14 -p npm@6 npm test -- --serial` (299 tests passed)
- `npx -p node@14 -p npm@6 node node_modules\c8\bin\c8.js report --reporter=text-summary --reporter=text`

Coverage moves from 96.22% to 96.61% statements; `themeUtils.js` now reports 100% statement, branch, function, and line coverage.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1: Needs more tests](https://oss.issuehunt.io/repos/87210037/issues/1)
---
</details>
<!-- /Issuehunt content-->