### PR TITLE
format: escape invisible and ambiguous string characters

### DIFF
--- a/lib/primitiveValues/string.js
+++ b/lib/primitiveValues/string.js
@@ -20,11 +20,26 @@ exports.deserialize = describe
 const tag = Symbol('StringValue')
 exports.tag = tag
 
-// TODO: Escape invisible characters (e.g. zero-width joiner, non-breaking space),
-// ambiguous characters (other kinds of spaces, combining characters). Use
-// http://graphemica.com/blocks/control-pictures where applicable.
+const MATCH_INVISIBLE_OR_AMBIGUOUS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u00A0\u00AD\u034F\u061C\u115F\u1160\u1680\u180E\u2000-\u200F\u2028-\u202F\u205F\u2060-\u206F\u3000\u3164\uFEFF]/g
+
+function toUnicodeEscape (char) {
+  const codePoint = char.codePointAt(0)
+  if (codePoint <= 0xFFFF) return `\\u${codePoint.toString(16).padStart(4, '0')}`
+  return `\\u{${codePoint.toString(16)}}`
+}
+
+function escapeInvisibleOrAmbiguous (char) {
+  if (char === '\t') return '\\t'
+  if (char === '\b') return '\\b'
+  if (char === '\v') return '\\v'
+  if (char === '\f') return '\\f'
+  return toUnicodeEscape(char)
+}
+
 function basicEscape (string) {
-  return string.replace(/\\/g, '\\\\')
+  return string
+    .replace(/\\/g, '\\\\')
+    .replace(MATCH_INVISIBLE_OR_AMBIGUOUS, escapeInvisibleOrAmbiguous)
 }
 
 const CRLF_CONTROL_PICTURE = '\u240D\u240A'

--- a/test/format.js
+++ b/test/format.js
@@ -104,6 +104,15 @@ test('escapes backticks in multi-line strings with the default theme', t => {
   t.snapshot(_format('`\n'), 'should be escaped')
 })
 
+test('escapes invisible and ambiguous characters in values and keys', t => {
+  const formattedValue = concordance.format('a\u00A0b\u200Dc')
+  t.true(formattedValue.includes('\\u00a0'))
+  t.true(formattedValue.includes('\\u200d'))
+
+  const formattedKey = concordance.format({ 'x\u00A0y': 1 })
+  t.true(formattedKey.includes('x\\u00a0y'))
+})
+
 test('formats a simple object', t => {
   const obj = { foo: 'bar', baz: 'qux' }
   const actual = format(obj)


### PR DESCRIPTION
## Summary
- Escape invisible / ambiguous characters during string formatting, including:
  - non-breaking space (`\u00A0`)
  - zero-width and directional/invisible Unicode ranges
  - non-linebreak control characters
- Preserve existing linebreak handling behavior.
- Add regression coverage for both string values and object string keys.

## Why
Issue #4 requests safer formatting output for characters that are hard to see or ambiguous.  
This patch makes those characters explicit through escape sequences while keeping existing format behavior stable for common text.

## Validation
- `npx ava test/format.js`
